### PR TITLE
RenderJupyter: Provide for rendering charts as displays in Jupyter notebooks (tcljupyter kernel)

### DIFF
--- a/chart.tcl
+++ b/chart.tcl
@@ -439,11 +439,12 @@ oo::define ticklecharts::chart {
 	
         try {
             set   fp [open $outputFile w+]
-            puts  $fp $jsonData
-            close $fp
+            puts  $fp $htmlData
         } on error {result options} {
             error [dict get $options -errorinfo]
-        }
+        } finally {
+	    close $fp
+	}
 
         if {$::ticklecharts::htmlstdout} {
             puts [format {html:%s} [file nativename $outputFile]]

--- a/global_options.tcl
+++ b/global_options.tcl
@@ -86,6 +86,7 @@ proc ticklecharts::htmlOptions {value} {
     setdef options -renderer   -minversion {}  -validvalue formatRenderer -type str.n              -default "canvas"
     setdef options -jschartvar -minversion {}  -validvalue {}             -type str.n              -default [format "chart_%s" $uuid]
     setdef options -divid      -minversion {}  -validvalue {}             -type str.n              -default [format "id_%s"    $uuid]
+    setdef options -outfile    -minversion {}  -validvalue {}             -type str.n              -default [file join [file dirname [info script]] render.html]
     setdef options -jsecharts  -minversion {}  -validvalue {}             -type str.n              -default $escript
     setdef options -jsvar      -minversion {}  -validvalue {}             -type str.n              -default [format "option_%s" $uuid]
     setdef options -script     -minversion {}  -validvalue {}             -type list.d|jsfunc|null -default "nothing"

--- a/global_options.tcl
+++ b/global_options.tcl
@@ -30,6 +30,39 @@ proc ticklecharts::globalOptions {value} {
     return [new edict $options]
 }
 
+proc ticklecharts::renderOptions {value} {
+    variable minProperties
+    variable escript
+    variable htmltemplate
+    
+    set minP $minProperties ; set minProperties 0
+
+    # Add '[ticklecharts::uuid]' command to generate random number generator.
+    set uuid [ticklecharts::uuid]
+
+    setdef options -outfile    -minversion {}  -validvalue {}             -type str.n              -default [file join [file dirname [info script]] render.html]
+
+    setdef options -title      -minversion {}  -validvalue {}             -type str.n              -default "ticklEcharts !!!"
+    setdef options -width      -minversion {}  -validvalue {}             -type str.n|num          -default "900px"
+    setdef options -height     -minversion {}  -validvalue {}             -type str.n|num          -default "500px"
+    setdef options -renderer   -minversion {}  -validvalue formatRenderer -type str.n              -default "canvas"
+    setdef options -jschartvar -minversion {}  -validvalue {}             -type str.n              -default [format "chart_%s" $uuid]
+    setdef options -divid      -minversion {}  -validvalue {}             -type str.n              -default [format "id_%s"    $uuid]
+    setdef options -jsecharts  -minversion {}  -validvalue {}             -type str.n              -default $escript
+    setdef options -jsvar      -minversion {}  -validvalue {}             -type str.n              -default [format "option_%s" $uuid]
+    setdef options -script     -minversion {}  -validvalue {}             -type list.d|jsfunc|null -default "nothing"
+    setdef options -class      -minversion {}  -validvalue {}             -type str.n              -default "chart-container"
+    setdef options -style      -minversion {}  -validvalue {}             -type str.n|null         -default "nothing"
+    setdef options -template   -minversion {}  -validvalue {}             -type str.n              -default $htmltemplate
+    
+    set options [merge $options $value]
+
+    set minProperties $minP
+
+    return $options
+
+}
+
 proc ticklecharts::htmlOptions {value} { 
     # Global options chart
     #
@@ -53,7 +86,6 @@ proc ticklecharts::htmlOptions {value} {
     setdef options -renderer   -minversion {}  -validvalue formatRenderer -type str.n              -default "canvas"
     setdef options -jschartvar -minversion {}  -validvalue {}             -type str.n              -default [format "chart_%s" $uuid]
     setdef options -divid      -minversion {}  -validvalue {}             -type str.n              -default [format "id_%s"    $uuid]
-    setdef options -outfile    -minversion {}  -validvalue {}             -type str.n              -default [file join [file dirname [info script]] render.html]
     setdef options -jsecharts  -minversion {}  -validvalue {}             -type str.n              -default $escript
     setdef options -jsvar      -minversion {}  -validvalue {}             -type str.n              -default [format "option_%s" $uuid]
     setdef options -script     -minversion {}  -validvalue {}             -type list.d|jsfunc|null -default "nothing"
@@ -67,6 +99,8 @@ proc ticklecharts::htmlOptions {value} {
 
     return $options
 }
+
+
 
 proc ticklecharts::tsbOptions {value} { 
     # Global options chart for Taygete Scrap Book


### PR DESCRIPTION
Thank you for `ticklecharts`, it is a very valuable asset!

I am currently working on an existing [Jupyter kernel implementation for Tcl](https://github.com/mpcjanssen/tcljupyter). Along the way, I explored ways of integrating charts into Jupyter notebooks (in the spirit of your RenderTsb for TSB). The main idea is to re-use the HTML export mechanism and pack the resulting HTML document into a `<iframe>`, to be rendered as a display in a Jupyter notebook.

There is a [presentation](https://learn.wu.ac.at/eurotcl2023/lecturecasts/690830938?m=delivery) of mine showcasing this chart integration, given at this year's EuroTcl conference (starting 00:13:30 approx.).

Some tests are pending, but the integration is operative and I am actively using it in my notebooks. Pls review my code changes and suggestions for improvements (refactorings). Feel also free to cherry pick, and let me know how my implementation could be improved.

Some details I am not confident about:

* Can option handling benefit from reuse: there is redundancy between the procs `renderOptions` and `htmlOptions`, although they share all option definitions.
* You keep providing `Render*` methods in subclasses of `chart`, with simple `next` calls. This is not necessary, unless I miss the obvious (subclasses inherit those methods). I do not have [`RenderJupyter`](https://github.com/nico-robert/ticklecharts/pull/1/files#diff-e9fedd1abdec7034fe445de6cbcdb875a3afa40127fe2e266e76905915dea55fR337) methods in subclasses, they still work for grid layouts etc.
* Method naming: `Render*` prefix vs. `to*` prefix.
* Should `toHtml` and `toIframe` be exported as well?

Hope you find this interesting, and worth incorporating!

Stefan (Sobernig) aka `mrcalvin` (in `#tcl` on IRC)